### PR TITLE
Limit the number of shown color swatches in product lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## 1.3.0
+
+### Added
+
+- Config to set the number of the color swatches that will be shown on product lists.
 
 ## 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Default value for unselected color (see example).
 ### swatchSizeUnselectedValue (json)
 Default value for unselected size(s) (see example).
 
+### numberOfShownSwatches (int)
+Reduces shown swatches to the configured number (enables only for > 0). If the number is 0, all swatches will be shown.
+
 #### Example of full config:
 ```json
 {
@@ -92,12 +95,13 @@ Default value for unselected size(s) (see example).
     }
   },
   "swatchLabels": {
-      "enabled": true,
-      "labels": {
-        "Color": false,
-        "Shoe size": "Size"
-      }
+    "enabled": true,
+    "labels": {
+      "Color": false,
+      "Shoe size": "Size"
     }
+  },
+  "numberOfShownSwatches": 5
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Default value for unselected color (see example).
 ### swatchSizeUnselectedValue (json)
 Default value for unselected size(s) (see example).
 
-### numberOfShownSwatches (int)
+### maxSwatches (int)
 Reduces shown swatches to the configured number (enables only for > 0). If the number is 0, all swatches will be shown.
 
 #### Example of full config:
@@ -101,7 +101,7 @@ Reduces shown swatches to the configured number (enables only for > 0). If the n
       "Shoe size": "Size"
     }
   },
-  "numberOfShownSwatches": 5
+  "maxSwatches": 5
 }
 ```
 

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.3.0",
   "id": "@shopgate-project/fashion-swatches",
   "configuration": {
     "swatchColorStyle": {
@@ -24,7 +24,7 @@
     "propertyWithColors": {
       "type": "admin",
       "destination": "frontend",
-      "default": "hexCodes",
+      "default": "Hexcodes",
       "params": {
         "label": "Name of the parent product property which contains color hexcodes of all variants",
         "type": "text",
@@ -34,7 +34,7 @@
     "propertyWithColor": {
       "type": "admin",
       "destination": "frontend",
-      "default": "hexCode",
+      "default": "",
       "params": {
         "label": "Name of the child product property which contains color hexcode",
         "type": "text",
@@ -90,7 +90,7 @@
     "colorAttribute": {
       "type": "admin",
       "destination": "frontend",
-      "default": "Farbe",
+      "default": "",
       "params": {
         "label": "The csv of product attributes names which are used as color swatch (eg. Color,Shoe color,Farbe)",
         "type": "text",
@@ -100,7 +100,7 @@
     "sizeAttribute": {
       "type": "admin",
       "destination": "frontend",
-      "default": ["Größe"],
+      "default": "",
       "params": {
         "label": "String array of product attributes names which are used as size swatch (eg. Size,Shoe size,Grosse)",
         "type": "json",
@@ -120,6 +120,15 @@
       "params": {
         "label": "Swatches optional labels",
         "type": "json"
+      }
+    },
+    "numberOfShownSwatches": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": 0,
+      "params": {
+        "type": "json",
+        "label": "Reduce shown swatches to the configured number. Enables only for > 0"
       }
     }
   },

--- a/extension-config.json
+++ b/extension-config.json
@@ -24,7 +24,7 @@
     "propertyWithColors": {
       "type": "admin",
       "destination": "frontend",
-      "default": "Hexcodes",
+      "default": "",
       "params": {
         "label": "Name of the parent product property which contains color hexcodes of all variants",
         "type": "text",
@@ -122,10 +122,10 @@
         "type": "json"
       }
     },
-    "numberOfShownSwatches": {
+    "maxSwatches": {
       "type": "admin",
       "destination": "frontend",
-      "default": 0,
+      "default": 5,
       "params": {
         "type": "json",
         "label": "Reduce shown swatches to the configured number. Enables only for > 0"

--- a/frontend/components/PlpSwatches/index.jsx
+++ b/frontend/components/PlpSwatches/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import connect from './connector';
 import styles from './style';
-import { numberOfShownSwatches } from '../../config';
+import { maxSwatches } from '../../config';
 
 /**
  * @param {Object} props Props
@@ -14,11 +14,11 @@ const PlpSwatches = ({ swatches }) => {
     return null;
   }
 
-  if (swatches.length > numberOfShownSwatches && numberOfShownSwatches !== 0) {
+  if (swatches.length > maxSwatches && maxSwatches !== 0) {
     return (
       <div>
         <ul className={styles.list}>
-          {swatches.slice(0, numberOfShownSwatches).map(swatch => (
+          {swatches.slice(0, maxSwatches).map(swatch => (
             <li
               className={styles.listItem}
               key={swatch}
@@ -26,9 +26,11 @@ const PlpSwatches = ({ swatches }) => {
               <div className={styles.swatch(swatch)} />
             </li>
           ))}
-          <div className={styles.numberOfShownSwatches}>
-            {`+ ${swatches.length - numberOfShownSwatches}`}
-          </div>
+          <li>
+            <div className={styles.maxSwatches}>
+              {`+ ${swatches.length - maxSwatches}`}
+            </div>
+          </li>
         </ul>
       </div>
     );

--- a/frontend/components/PlpSwatches/index.jsx
+++ b/frontend/components/PlpSwatches/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import connect from './connector';
 import styles from './style';
+import { numberOfShownSwatches } from '../../config';
 
 /**
  * @param {Object} props Props
@@ -11,6 +12,26 @@ import styles from './style';
 const PlpSwatches = ({ swatches }) => {
   if (!swatches || !swatches.length) {
     return null;
+  }
+
+  if (swatches.length > numberOfShownSwatches && numberOfShownSwatches !== 0) {
+    return (
+      <div>
+        <ul className={styles.list}>
+          {swatches.slice(0, numberOfShownSwatches).map(swatch => (
+            <li
+              className={styles.listItem}
+              key={swatch}
+            >
+              <div className={styles.swatch(swatch)} />
+            </li>
+          ))}
+          <div className={styles.numberOfShownSwatches}>
+            {`+ ${swatches.length - numberOfShownSwatches}`}
+          </div>
+        </ul>
+      </div>
+    );
   }
 
   return (

--- a/frontend/components/PlpSwatches/style.js
+++ b/frontend/components/PlpSwatches/style.js
@@ -31,8 +31,13 @@ const swatch = bg => css({
   background: bg,
 });
 
+const numberOfShownSwatches = css({
+  marginTop: '-2.5px',
+});
+
 export default {
   list,
   listItem,
   swatch,
+  numberOfShownSwatches,
 };

--- a/frontend/components/PlpSwatches/style.js
+++ b/frontend/components/PlpSwatches/style.js
@@ -31,7 +31,7 @@ const swatch = bg => css({
   background: bg,
 });
 
-const numberOfShownSwatches = css({
+const maxSwatches = css({
   marginTop: '-2.5px',
 });
 
@@ -39,5 +39,5 @@ export default {
   list,
   listItem,
   swatch,
-  numberOfShownSwatches,
+  maxSwatches,
 };


### PR DESCRIPTION
## Description

This adaption adds a config and the function to limit the number of shown color swatches in product lists. It adds a config `numberOfShownSwatches` (int) to set a fix number of swatches shown in product lists. It also adds the information how many color swatches are there besides the shown ones (+1. +2, +3 etc.).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md