### PR TITLE
Add link swatch and logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.4.0
+
+### Added
+
+- Config and logic to add a link swatch.
+
 ## 1.3.1
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shopgate Connect - Fashion swatches
 
-This extension adds color swatches to PLP and PDP.
+This extension adds color swatches and link swatches to PLP and PDP.
 Configured attributes/characteristics are shown in a fashion optimized styling on PDP.
 
 ## Configuration
@@ -14,6 +14,13 @@ CSS styling for swatches as glamor object. Can be any css properties and values.
     - disabled: disabled state (no available product, etc)
 
 ### swatchSizeStyle (json)
+CSS styling for swatches as glamor object. Can be any css properties and values.
+- pdp: styling for swatches on product detail page
+    - default: default state
+    - selected: selected state
+    - disabled: disabled state (no available product, etc)
+
+### swatchLinkStyle (json)
 CSS styling for swatches as glamor object. Can be any css properties and values.
 - pdp: styling for swatches on product detail page
     - default: default state
@@ -47,6 +54,19 @@ Default value for unselected size(s) (see example).
 
 ### maxSwatches (int)
 Reduces shown swatches to the configured number (enables only for > 0). If the number is 0, all swatches will be shown.
+
+### pdpSwatchesDisplayMode (string)
+Swatches are shown with and headline or a lable-swatch (e.g. normal and headline).
+
+### pdpSwatchesPosition (string)
+Position of swatches on PDP. (e.g. sticky-buttons or variants).
+
+### linkSwatchConfiguration (json)
+Configuration for the link swatch
+- `type` (string) Can be `color` to show a color-link-swatch or `image` to show an image-link-swatch.
+- `property` (string) Property that contains the linkSwatch information (see dependencies).
+- `showAdditionalText` (boolean) Shows an additional text underneath the link-swatch.
+- `historyReplace` (boolean) Replaces the route history.
 
 #### Example of full config:
 ```json
@@ -101,7 +121,26 @@ Reduces shown swatches to the configured number (enables only for > 0). If the n
       "Shoe size": "Size"
     }
   },
-  "maxSwatches": 5
+  "maxSwatches": 5,
+  "pdpSwatchesDisplayMode": "normal",
+  "pdpSwatchesPosition": "sticky-buttons",
+  "swatchLinkStyle": {
+    "pdp": {
+      "default": null,
+      "selected": {
+        "border": "2px solid blue"
+      },
+      "disabled":  {
+        "opacity": "0.5"
+      }
+    }
+  },
+  "linkSwatchConfiguration": {
+    "type": "color",
+    "property": "linkSwatch",
+    "showAdditionalText": true,
+    "historyReplace": false
+  }
 }
 ```
 
@@ -111,6 +150,15 @@ Reduces shown swatches to the configured number (enables only for > 0). If the n
     - `addProperties` config. Add the product properties that are configured for this extension.
         - propertyWithColors
         - propertyWithColor
+- Needs a property with the following values
+  - ````{"linkSwatch":{"name":{"label":"","itemNumber":"","hexcode":"","additionalText":"","imgUrl":""},"name2":{"label2":"","itemNumber2":"","hexcode2":"","additionalText2":"","imgUrl2":""}}}````
+    - `linkSwatch`: is the property name.
+    - `name`: Is the name of an entry.
+    - `label`: The label is shown inside the swatch.
+    - `itemNumber`: The itemNumber - is needed for the redirect to the product.
+    - `hexcode`: Is needed for the `swatchType`:`color`. The swatch will be shown with this background color. 
+    - `additionalText`: Is shown underneath the swatch. 
+    - `imgUrl`: Is needed for the `swatchType`:`image`. The swatch will show this image.
 
 ## About Shopgate
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ CSS styling for swatches as glamor object. Can be any css properties and values.
     - default: default state
     - selected: selected state
     - disabled: disabled state (no available product, etc)
+- pdpTablet: styling for swatches on product detail page for tablets
+  - default: default state
+  - selected: selected state
+  - disabled: disabled state (no available product, etc)
+
 
 ### swatchSizeStyle (json)
 CSS styling for swatches as glamor object. Can be any css properties and values.
@@ -19,6 +24,10 @@ CSS styling for swatches as glamor object. Can be any css properties and values.
     - default: default state
     - selected: selected state
     - disabled: disabled state (no available product, etc)
+- pdpTablet: styling for swatches on product detail page for tablets
+  - default: default state
+  - selected: selected state
+  - disabled: disabled state (no available product, etc)
 
 ### swatchLinkStyle (json)
 CSS styling for swatches as glamor object. Can be any css properties and values.
@@ -26,6 +35,10 @@ CSS styling for swatches as glamor object. Can be any css properties and values.
     - default: default state
     - selected: selected state
     - disabled: disabled state (no available product, etc)
+- pdpTablet: styling for swatches on product detail page for tablets
+  - default: default state
+  - selected: selected state
+  - disabled: disabled state (no available product, etc)
 
 ### propertyWithColors (string[])
 Name of the parent product property which contains all colors of children.

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0-beta.12",
+  "version": "1.4.0-beta.14",
   "id": "@shopgate-project/fashion-swatches",
   "configuration": {
     "swatchColorStyle": {

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.4.0-beta.12",
   "id": "@shopgate-project/fashion-swatches",
   "configuration": {
     "swatchColorStyle": {

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.1",
+  "version": "1.4.0",
   "id": "@shopgate-project/fashion-swatches",
   "configuration": {
     "swatchColorStyle": {
@@ -46,11 +46,11 @@
       "destination": "frontend",
       "default": {
         "pdp": {
-          "default": null,
-          "selected": {
-            "background": "#000",
-            "color": "#fff",
+          "default": {
             "boxShadow": "none"
+          },
+          "selected": {
+            "border": "1px solid #000"
           },
           "disabled": null
         }
@@ -111,10 +111,11 @@
       "type": "admin",
       "destination": "frontend",
       "default": {
-        "enabled": false,
+        "enabled": true,
         "labels": {
           "Color": false,
-          "Size": "Size"
+          "Size": "Size",
+          "Link": "Link"
         }
       },
       "params": {
@@ -130,6 +131,60 @@
         "type": "json",
         "label": "Reduce shown swatches to the configured number. Enables only for > 0"
       }
+    },
+    "pdpSwatchesDisplayMode": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": "normal",
+      "params": {
+        "label": "Swatches are shown with and headline or a lable-swatch (e.g. normal and headline)",
+        "type": "text",
+        "required": true
+      }
+    },
+    "pdpSwatchesPosition": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": "sticky-buttons",
+      "params": {
+        "label": "Position of swatches on PDP. (e.g. sticky-buttons or variants)",
+        "type": "text",
+        "required": true
+      }
+    },
+    "swatchLinkStyle": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": {
+        "plp": null,
+        "pdp": {
+          "default": null,
+          "selected": {
+            "boxShadow": "0px 0px 0px 2px white"
+          },
+          "disabled": null
+        }
+      },
+      "params": {
+        "label": "CSS styling for color swatches as glamor object",
+        "type": "json",
+        "required": true
+      }
+    },
+    "linkSwatchConfiguration": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": {
+        "type": "",
+        "property": "",
+        "showAdditionalText": false,
+        "historyReplace": false
+      },
+      "params": {
+        "label": "Configuration for the link swatch",
+        "type": "json",
+        "required": true
+      }
     }
   },
   "components": [
@@ -144,7 +199,8 @@
       "path": "frontend/components/PdpSwatches",
       "target": [
         "product.sticky-buttons.between",
-        "product.tablet.right-column.after"
+        "product.variant-select.after",
+        "product.tablet.right-column.add-to-cart.before"
       ],
       "type": "portals"
     },

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0-beta.9",
+  "version": "1.4.0-beta.10",
   "id": "@shopgate-project/fashion-swatches",
   "configuration": {
     "swatchColorStyle": {

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0-beta.10",
+  "version": "1.4.0-beta.11",
   "id": "@shopgate-project/fashion-swatches",
   "configuration": {
     "swatchColorStyle": {

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0-beta.11",
+  "version": "1.4.0",
   "id": "@shopgate-project/fashion-swatches",
   "configuration": {
     "swatchColorStyle": {
@@ -111,7 +111,7 @@
       "type": "admin",
       "destination": "frontend",
       "default": {
-        "enabled": true,
+        "enabled": false,
         "labels": {
           "Color": false,
           "Size": "Size",

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.4.0-beta.9",
   "id": "@shopgate-project/fashion-swatches",
   "configuration": {
     "swatchColorStyle": {

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0-beta.14",
+  "version": "1.4.0",
   "id": "@shopgate-project/fashion-swatches",
   "configuration": {
     "swatchColorStyle": {

--- a/extension-config.json
+++ b/extension-config.json
@@ -111,7 +111,7 @@
       "type": "admin",
       "destination": "frontend",
       "default": {
-        "enabled": true,
+        "enabled": false,
         "labels": {
           "Color": false,
           "Size": "Size",

--- a/extension-config.json
+++ b/extension-config.json
@@ -46,11 +46,11 @@
       "destination": "frontend",
       "default": {
         "pdp": {
-          "default": {
-            "boxShadow": "none"
-          },
+          "default": null,
           "selected": {
-            "border": "1px solid #000"
+            "background": "#000",
+            "color": "#fff",
+            "boxShadow": "none"
           },
           "disabled": null
         }
@@ -111,7 +111,7 @@
       "type": "admin",
       "destination": "frontend",
       "default": {
-        "enabled": false,
+        "enabled": true,
         "labels": {
           "Color": false,
           "Size": "Size",
@@ -135,9 +135,9 @@
     "pdpSwatchesDisplayMode": {
       "type": "admin",
       "destination": "frontend",
-      "default": "normal",
+      "default": "swatch",
       "params": {
-        "label": "Swatches are shown with and headline or a lable-swatch (e.g. normal and headline)",
+        "label": "Swatches are shown with and headline or a lable-swatch (e.g. swatch and headline)",
         "type": "text",
         "required": true
       }

--- a/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
+++ b/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
@@ -60,8 +60,8 @@ const styles = {
   }).toString(),
   swatch: css({
     '&&': {
-      height: 25,
-      width: 25,
+      height: 35,
+      width: 35,
       marginRight: 10,
       marginLeft: 10,
     },
@@ -192,114 +192,6 @@ const FoldableSwatchesUnfolded = ({
     }
   }, [values, label, isTablet, highlighted]);
 
-  if (isLinkSwatch) {
-    return (
-      <Transition
-        in={highlighted}
-        timeout={1500}
-        onEntered={() => setHighlighted(false)}
-      >
-        {state => (
-          <div className={styles.swatchesContainer}>
-            {label && pdpSwatchesDisplayMode === 'headline' && pdpSwatchesPosition === 'variants' && (
-              <p className={styles.swatchHeadline}>{label}</p>
-            )}
-            <ul
-              className={classnames(
-                styles.swatches,
-                transitions[state],
-                transitions[fade],
-                {
-                  [styles.swatchesTablet]: isTablet,
-                }
-              )}
-            >
-              {label && (pdpSwatchesDisplayMode !== 'headline' || pdpSwatchesPosition !== 'variants') && (
-                <Swatch
-                  key="label"
-                  style={sizeStyle.default}
-                  className={classnames(
-                    styles.swatch,
-                    isTablet && styles.swatchTablet,
-                    styles.labelSwatch,
-                    isTablet && styles.labelSwatchTablet
-                  )}
-                >
-                  {label}
-                </Swatch>
-              )}
-              <ConditionalWrapper
-                condition={isTablet}
-                wrapper={children => (
-                  <div className={styles.swatchesContainerTablet}>
-                    {children}
-                  </div>
-                )}
-              >
-                {values.map(value => (
-                  <Link
-                    href={`/item/${bin2hex(value.itemNumber)}`}
-                    className={styles.linkSwatch}
-                    replace={historyReplace}
-                  >
-                    <Swatch
-                      tagName="li"
-                      style={{
-                        ...value.swatchColor && {
-                          background: value.swatchColor,
-                          ...linkStyle.default,
-                          ...value.selected && linkStyle.selected,
-                          ...!value.selectable && linkStyle.disabled,
-                          ...(value.selected ? {
-                            boxShadow: '0px 0px 0px 1px #000',
-                            border: isTablet ? '4px solid' : '3px solid',
-                            borderColor: '#fff',
-                          } : null),
-                        },
-                        ...value.swatchImage && {
-                          background: `url(${value.swatchImage})`,
-                          height: 70,
-                          width: 70,
-                          color: '#fff',
-                          ...linkStyle.default,
-                          ...value.selected && linkStyle.selected,
-                          ...!value.selectable && linkStyle.disabled,
-                          ...(value.selected ? {
-                            boxShadow: '0px 0px 0px 1px #000',
-                            border: isTablet ? '4px solid' : '3px solid',
-                            borderColor: '#fff',
-                          } : null),
-                        },
-                        ...value.swatchLabel && {
-                          ...linkStyle.default,
-                          ...value.selected && linkStyle.selected,
-                          ...!value.selectable && linkStyle.disabled,
-                          ...(value.selected && isTablet ? { boxShadow: '0px 0px 0px 2px #000' } : null),
-                        },
-                      }}
-                      className={classnames({
-                        [styles.selected]: value.selected && !isTablet,
-                        [styles.selectedTablet]: value.selected && isTablet,
-                        [styles.disabled]: !value.selectable,
-                        [styles.disabledTablet]: isTablet && !value.selectable,
-                      }, styles.swatch, isTablet && styles.swatchTablet)}
-                      onClick={() => onClick(value)}
-                    >
-                      {value.swatchLabel}
-                    </Swatch>
-                    {showAdditionalText && (
-                    <p style={{ fontSize: '0.7rem' }}>{value.additionalText}</p>
-                    )}
-                  </Link>
-                ))}
-              </ConditionalWrapper>
-            </ul>
-          </div>
-        )}
-      </Transition>
-    );
-  }
-
   return (
     <Transition
       in={highlighted}
@@ -345,36 +237,83 @@ const FoldableSwatchesUnfolded = ({
               )}
             >
               {values.map(value => (
-                <Swatch
-                  key={value.id}
-                  tagName="li"
-                  style={{
-                    ...value.swatchColor && {
-                      background: value.swatchColor,
-                      ...colorStyle.default,
-                      ...value.selected && colorStyle.selected,
-                      ...!value.selectable && colorStyle.disabled,
-                      ...(value.selected && isTablet ? {
-                        boxShadow: `0px 0px 0px 2px ${getContrastColor(value.color, '#525345', value.color)}`,
-                        borderColor: '#fff',
-                      } : null),
-                    },
-                    ...value.swatchLabel && {
-                      ...sizeStyle.default,
-                      ...value.selected && sizeStyle.selected,
-                      ...!value.selectable && sizeStyle.disabled,
-                    },
-                  }}
-                  className={classnames({
-                    [styles.selected]: value.selected && !isTablet,
-                    [styles.selectedTablet]: value.selected && isTablet,
-                    [styles.disabled]: !value.selectable,
-                    [styles.disabledTablet]: isTablet && !value.selectable,
-                  }, styles.swatch, isTablet && styles.swatchTablet)}
-                  onClick={() => onClick(value)}
+                <ConditionalWrapper
+                  condition={isLinkSwatch}
+                  wrapper={children => (
+                    <Link
+                      href={`/item/${bin2hex(value.itemNumber)}`}
+                      className={styles.linkSwatch}
+                      replace={historyReplace}
+                    >
+                      {children}
+                    </Link>
+                  )}
                 >
-                  {value.swatchLabel}
-                </Swatch>
+                  <Swatch
+                    tagName="li"
+                    style={{
+                      ...value.swatchColor && isLinkSwatch && {
+                        background: value.swatchColor,
+                        ...linkStyle.default,
+                        ...value.selected && linkStyle.selected,
+                        ...!value.selectable && linkStyle.disabled,
+                        ...(value.selected ? {
+                          boxShadow: `0px 0px 0px 1px ${getContrastColor(value.color, '#525345', value.color)}`,
+                          border: isTablet ? '4px solid' : '3px solid',
+                          borderColor: '#fff',
+                        } : null),
+                      },
+                      ...value.swatchColor && !isLinkSwatch && {
+                        background: value.swatchColor,
+                        ...colorStyle.default,
+                        ...value.selected && colorStyle.selected,
+                        ...!value.selectable && colorStyle.disabled,
+                        ...(value.selected ? {
+                          boxShadow: `0px 0px 0px 1px ${getContrastColor(value.color, '#525345', value.color)}`,
+                          border: isTablet ? '4px solid' : '3px solid',
+                          borderColor: '#fff',
+                        } : null),
+                      },
+                      ...value.swatchImage && {
+                        background: `url(${value.swatchImage})`,
+                        height: 70,
+                        width: 70,
+                        color: '#fff',
+                        ...linkStyle.default,
+                        ...value.selected && linkStyle.selected,
+                        ...!value.selectable && linkStyle.disabled,
+                        ...(value.selected ? {
+                          boxShadow: '0px 0px 0px 1px #000',
+                          border: isTablet ? '4px solid' : '3px solid',
+                          borderColor: '#fff',
+                        } : null),
+                      },
+                      ...value.swatchLabel && isLinkSwatch && {
+                        ...linkStyle.default,
+                        ...value.selected && linkStyle.selected,
+                        ...!value.selectable && linkStyle.disabled,
+                        ...(value.selected && isTablet ? { boxShadow: '0px 0px 0px 2px #000' } : null),
+                      },
+                      ...value.swatchLabel && !isLinkSwatch && {
+                        ...sizeStyle.default,
+                        ...value.selected && sizeStyle.selected,
+                        ...!value.selectable && sizeStyle.disabled,
+                      },
+                    }}
+                    className={classnames({
+                      [styles.selected]: value.selected && !isTablet,
+                      [styles.selectedTablet]: value.selected && isTablet,
+                      [styles.disabled]: !value.selectable,
+                      [styles.disabledTablet]: isTablet && !value.selectable,
+                    }, styles.swatch, isTablet && styles.swatchTablet)}
+                    onClick={() => onClick(value)}
+                  >
+                    {value.swatchLabel}
+                  </Swatch>
+                  {showAdditionalText && (
+                  <p style={{ fontSize: '0.7rem' }}>{value.additionalText}</p>
+                  )}
+                </ConditionalWrapper>
               ))}
             </ConditionalWrapper>
           </ul>

--- a/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
+++ b/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
@@ -36,6 +36,7 @@ const styles = {
     transition: 'opacity 1.5s',
     boxShadow: 'none !important',
     justifyContent: pdpSwatchesPosition === 'variants' ? 'safe center' : 'start',
+    alignItems: 'center',
     ' li': {
       marginRight: 20,
     },
@@ -48,6 +49,7 @@ const styles = {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: '16px 0',
+    alignItems: 'center',
   }).toString(),
   withLabel: css({
     width: 'calc(100% - 16px)',

--- a/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
+++ b/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
@@ -92,7 +92,6 @@ const styles = {
   }).toString(),
   swatchesContainer: css({
     marginBottom: 20,
-    background: 'lightgrey',
   }).toString(),
   linkSwatch: css({
     width: 'unset',

--- a/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
+++ b/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
@@ -35,7 +35,7 @@ const styles = {
     opacity: 0,
     transition: 'opacity 1.5s',
     boxShadow: 'none !important',
-    justifyContent: pdpSwatchesPosition === 'variants' ? 'safe center' : 'start',
+    justifyContent: pdpSwatchesPosition === 'variants' ? 'unset' : 'start',
     ' li': {
       marginRight: 20,
     },
@@ -96,6 +96,7 @@ const styles = {
   linkSwatch: css({
     width: 'unset',
     textAlign: 'center',
+    margin: pdpSwatchesPosition === 'variants' ? 'auto' : 'unset',
   }).toString(),
   swatchHeadline: css({
     marginBottom: 5,

--- a/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
+++ b/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
@@ -303,7 +303,7 @@ const FoldableSwatchesUnfolded = ({
                             borderColor: '#fff',
                           } : null),
                         },
-                        ...value.swatchLabel && isLinkSwatch && {
+                        ...isLinkSwatch && value.swatchLabel && !value.swatchColor && {
                           ...linkStyle.default,
                           ...value.selected && linkStyle.selected,
                           ...!value.selectable && linkStyle.disabled,

--- a/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
+++ b/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
@@ -35,7 +35,7 @@ const styles = {
     opacity: 0,
     transition: 'opacity 1.5s',
     boxShadow: 'none !important',
-    justifyContent: pdpSwatchesPosition === 'variants' ? 'center' : 'start',
+    justifyContent: pdpSwatchesPosition === 'variants' ? 'safe center' : 'start',
     ' li': {
       marginRight: 20,
     },

--- a/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
+++ b/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
@@ -35,7 +35,7 @@ const styles = {
     opacity: 0,
     transition: 'opacity 1.5s',
     boxShadow: 'none !important',
-    justifyContent: pdpSwatchesPosition === 'variants' ? 'unset' : 'start',
+    justifyContent: pdpSwatchesPosition === 'variants' ? 'center' : 'start',
     ' li': {
       marginRight: 20,
     },
@@ -48,6 +48,7 @@ const styles = {
     flexDirection: 'row',
     flexWrap: 'wrap',
     gap: '16px 0',
+    justifyContent: 'center',
   }).toString(),
   withLabel: css({
     width: 'calc(100% - 16px)',
@@ -96,7 +97,6 @@ const styles = {
   linkSwatch: css({
     width: 'unset',
     textAlign: 'center',
-    margin: pdpSwatchesPosition === 'variants' ? 'auto' : 'unset',
   }).toString(),
   swatchHeadline: css({
     marginBottom: 5,

--- a/frontend/components/FoldableSwatches/index.jsx
+++ b/frontend/components/FoldableSwatches/index.jsx
@@ -4,7 +4,7 @@ import { css } from 'glamor';
 import classnames from 'classnames';
 import Swatch from '../Swatch';
 import Unfolded from './components/Unfolded';
-import { swatchColorStyle, swatchSizeStyle } from '../../config';
+import { swatchColorStyle, swatchSizeStyle, pdpSwatchesPosition } from '../../config';
 
 const { pdp: colorStyle } = swatchColorStyle;
 const { pdp: sizeStyle } = swatchSizeStyle;
@@ -30,9 +30,16 @@ const styles = {
  * @return {JSX}
  */
 const FoldableSwatches = ({
-  values, onClick, requireSelection, defaultValue, label, isTablet,
+  values,
+  onClick,
+  requireSelection,
+  defaultValue,
+  label,
+  isTablet,
+  isLinkSwatch,
+  showAdditionalText,
 }) => {
-  const [isFolded, setIsFolded] = useState(!isTablet);
+  const [isFolded, setIsFolded] = useState(!isTablet && pdpSwatchesPosition !== 'variants');
 
   // Receive props
   useEffect(() => setIsFolded((wasFolded) => {
@@ -44,7 +51,7 @@ const FoldableSwatches = ({
 
   const unfoldedClick = useCallback((value) => {
     onClick(value);
-    if (!isTablet) {
+    if (!isTablet && pdpSwatchesPosition !== 'variants') {
       setIsFolded(true);
     }
   }, [onClick, isTablet]);
@@ -88,6 +95,8 @@ const FoldableSwatches = ({
       highlight={requireSelection}
       label={label}
       isTablet={isTablet}
+      isLinkSwatch={isLinkSwatch}
+      showAdditionalText={showAdditionalText}
     />
   );
 };
@@ -96,14 +105,18 @@ FoldableSwatches.propTypes = {
   isTablet: PropTypes.bool.isRequired,
   onClick: PropTypes.func.isRequired,
   defaultValue: PropTypes.shape(),
+  isLinkSwatch: PropTypes.bool,
   label: PropTypes.string,
   requireSelection: PropTypes.bool,
+  showAdditionalText: PropTypes.bool,
   values: PropTypes.arrayOf(PropTypes.shape()),
 };
 
 FoldableSwatches.defaultProps = {
   requireSelection: false,
+  isLinkSwatch: false,
   label: null,
+  showAdditionalText: false,
   values: null,
   defaultValue: null,
 };

--- a/frontend/components/PdpColorSwatch/index.jsx
+++ b/frontend/components/PdpColorSwatch/index.jsx
@@ -56,7 +56,8 @@ const PdpColorSwatch = ({
   }, [swatch, characteristics]);
 
   let label;
-  if (swatchLabels.enabled) {
+
+  if (swatchLabels.enabled && swatch) {
     if (swatchLabels.labels[swatch.label] !== false) {
       label = swatchLabels.labels[swatch.label] || swatch.label;
     }

--- a/frontend/components/PdpSizeSwatch/index.jsx
+++ b/frontend/components/PdpSizeSwatch/index.jsx
@@ -64,7 +64,7 @@ const PdpSizeSwatch = ({
   }, [swatch, products, characteristics, siblingSizeIds]);
 
   let label;
-  if (swatchLabels.enabled) {
+  if (swatchLabels.enabled && swatch) {
     if (swatchLabels.labels[swatch.label] !== false) {
       label = swatchLabels.labels[swatch.label] || swatch.label;
     }

--- a/frontend/components/PdpSwatches/index.jsx
+++ b/frontend/components/PdpSwatches/index.jsx
@@ -6,11 +6,14 @@ import { ConditionalWrapper } from '@shopgate/engage/components';
 import { useNavigateToVariant, useRouteCharacteristics } from '../../variants/hook';
 import PdpColorSwatch from '../PdpColorSwatch';
 import PdpSizeSwatches from '../PdpSizeSwatches';
+import PdpLinkSwatch from '../pdpLinkSwatch';
 import connect from './connector';
+import { pdpSwatchesPosition } from '../../config';
 
 const styles = {
   containerTablet: css({
     paddingTop: 16,
+    paddingBottom: 16,
   }),
 };
 
@@ -23,7 +26,6 @@ const PdpSwatches = ({
 }) => {
   const { contexts: { ProductContext } } = useContext(ThemeContext);
   const pdpContext = useContext(ProductContext);
-
   const { variantId, characteristics } = pdpContext;
 
   useNavigateToVariant(products);
@@ -33,6 +35,7 @@ const PdpSwatches = ({
     if (!swatchCharacteristicIds) {
       return pdpContext;
     }
+
     if (variantId) {
       const missingChars = swatchCharacteristicIds.filter(char => (
         !characteristics || !characteristics[char]
@@ -53,9 +56,13 @@ const PdpSwatches = ({
     return pdpContext;
   }, [products, pdpContext, variantId, characteristics, swatchCharacteristicIds]);
 
-  // When the fashion-swatches extension is rendered on tablets, the component needs to render
+  // When the fashion-swatches extension is rendered on tablets or
+  // swatches position is configured to be shown at the normal variants position,
+  // the component needs to render
   // in a different portal than usual.
-  if (!swatchCharacteristicIds || (isTablet && name !== 'product.tablet.right-column.after')) {
+  if (!swatchCharacteristicIds || (isTablet && name !== 'product.tablet.right-column.add-to-cart.before') ||
+  (!isTablet && pdpSwatchesPosition === 'variants' && name !== 'product.variant-select.after') ||
+  (!isTablet && pdpSwatchesPosition !== 'variants' && name === 'product.variant-select.after')) {
     return null;
   }
 
@@ -69,6 +76,7 @@ const PdpSwatches = ({
       )}
     >
       <ProductContext.Provider value={prodContext}>
+        <PdpLinkSwatch productId={pdpContext.productId} />
         <PdpColorSwatch productId={pdpContext.productId} />
         <PdpSizeSwatches productId={pdpContext.productId} />
       </ProductContext.Provider>

--- a/frontend/components/pdpLinkSwatch/connector.js
+++ b/frontend/components/pdpLinkSwatch/connector.js
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux';
+import {
+  getIsTablet,
+  getLinkSwatch,
+} from '../../variants/selectors';
+
+/**
+ * @param {Object} state state
+ * @param {Object} props props
+ * @returns {Object}
+ */
+const mapStateToProps = (state, { productId }) => ({
+  isTablet: getIsTablet(state),
+  linkSwatch: getLinkSwatch(state, { productId }),
+});
+
+export default connect(mapStateToProps);

--- a/frontend/components/pdpLinkSwatch/index.jsx
+++ b/frontend/components/pdpLinkSwatch/index.jsx
@@ -48,7 +48,7 @@ const PdpLinkSwatch = ({ productId, isTablet, linkSwatch }) => {
 
   /**
    * Pseudo function
-   @returns {void}
+   * @returns {void}
    */
   const pseudoFunction = () => null;
 

--- a/frontend/components/pdpLinkSwatch/index.jsx
+++ b/frontend/components/pdpLinkSwatch/index.jsx
@@ -60,7 +60,7 @@ const PdpLinkSwatch = ({ productId, isTablet, linkSwatch }) => {
       defaultValue={swatchColorUnselectedValue}
       label={swatchLabels.enabled ? label : null}
       isTablet={isTablet}
-      isLinkSwatch={!false}
+      isLinkSwatch
       showAdditionalText={linkSwatchConfiguration.showAdditionalText}
     />
   );

--- a/frontend/components/pdpLinkSwatch/index.jsx
+++ b/frontend/components/pdpLinkSwatch/index.jsx
@@ -1,0 +1,80 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import FoldableSwatches from '../FoldableSwatches';
+import connect from './connector';
+import { swatchColorUnselectedValue, swatchLabels, linkSwatchConfiguration } from '../../config';
+
+/**
+ * @param {Object} props Props
+ * @return {JSX}
+ */
+const PdpLinkSwatch = ({ productId, isTablet, linkSwatch }) => {
+  const values = useMemo(() => {
+    if (!linkSwatch || !linkSwatch.length) {
+      return null;
+    }
+
+    const linkSwatchValues = [];
+
+    linkSwatch.map((swatch) => {
+      Object.keys(swatch).map((value) => {
+        linkSwatchValues.push({
+          id: value,
+          itemNumber: swatch[value].itemNumber,
+          swatchLabel: null,
+          swatchColor: swatch[value].hexcode,
+          selected: productId === swatch[value].itemNumber,
+          selectable: true,
+          swatchImage: null,
+          additionalText: swatch[value].label,
+        });
+        return null;
+      });
+      return null;
+    });
+
+    return linkSwatchValues;
+  }, [linkSwatch, productId]);
+
+  const [requireSelection, setRequireSelection] = useState(false);
+
+  useEffect(() => {
+    if (requireSelection) {
+      setTimeout(() => setRequireSelection(false), 500);
+    }
+  }, [requireSelection]);
+
+  const label = swatchLabels.labels.Link || '';
+
+  /**
+   * Pseudo function
+   @returns {void}
+   */
+  const pseudoFunction = () => null;
+
+  return (
+    <FoldableSwatches
+      onClick={pseudoFunction}
+      values={values}
+      requireSelection={requireSelection}
+      defaultValue={swatchColorUnselectedValue}
+      label={swatchLabels.enabled ? label : null}
+      isTablet={isTablet}
+      isLinkSwatch={!false}
+      showAdditionalText={linkSwatchConfiguration.showAdditionalText}
+    />
+  );
+};
+
+PdpLinkSwatch.propTypes = {
+  isTablet: PropTypes.bool.isRequired,
+  linkSwatch: PropTypes.arrayOf(PropTypes.shape()),
+  productId: PropTypes.string,
+};
+
+PdpLinkSwatch.defaultProps = {
+  linkSwatch: {},
+  productId: '',
+};
+
+export default connect(PdpLinkSwatch);

--- a/frontend/components/pdpLinkSwatch/index.jsx
+++ b/frontend/components/pdpLinkSwatch/index.jsx
@@ -21,11 +21,11 @@ const PdpLinkSwatch = ({ productId, isTablet, linkSwatch }) => {
         linkSwatchValues.push({
           id: value,
           itemNumber: swatch[value].itemNumber,
-          swatchLabel: null,
+          swatchLabel: swatch[value].label,
           swatchColor: swatch[value].hexcode,
           selected: productId === swatch[value].itemNumber,
           selectable: true,
-          swatchImage: null,
+          swatchImage: swatch[value].img,
           additionalText: swatch[value].label,
         });
         return null;

--- a/frontend/variants/selectors.js
+++ b/frontend/variants/selectors.js
@@ -1,7 +1,8 @@
 import { createSelector } from 'reselect';
-import { getProducts } from '@shopgate/engage/product';
+import { getProducts, getProduct } from '@shopgate/engage/product';
 import { getDeviceInformation } from '@shopgate/engage/core';
 import { getColorSwatch, getSizeSwatches, getSwatchCharacteristicIds as getIds } from './helpers';
+import { linkSwatchConfiguration } from '../config';
 
 /**
  * @param {Object} state .
@@ -88,4 +89,30 @@ export const getSwatchCharacteristicIds = createSelector(
 export const getIsTablet = createSelector(
   getDeviceInformation,
   deviceInformation => deviceInformation && deviceInformation.type === 'tablet'
+);
+
+export const getLinkSwatch = createSelector(
+  getProduct,
+  (productData) => {
+    if (
+      !productData ||
+      productData.isFetching ||
+      !productData.additionalProperties ||
+      !linkSwatchConfiguration ||
+      !linkSwatchConfiguration.property
+    ) {
+      return null;
+    }
+
+    const linkSwatchProperty = linkSwatchConfiguration.property;
+
+    const linkSwatch = productData.additionalProperties
+      .find(prop => prop.label === linkSwatchProperty);
+
+    if (linkSwatch) {
+      return linkSwatch.value;
+    }
+
+    return null;
+  }
 );


### PR DESCRIPTION
## Description

Adds the logic to configure a link swatch that redirects to another product via the item number. The link swatch can be of type `color` or `image`. 

The link swatch depends on a property that contains the following information.

`{"linkSwatch":{"name":{"label":"","itemNumber":"","hexcode":"","additionalText":"","imgUrl":""},"name2":{"label2":"","itemNumber2":"","hexcode2":"","additionalText2":"","imgUrl2":""}}}`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md