### PR TITLE
CURB-5439 Display the currently selected color in the headline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.7.0
+
+### Added
+
+- Added config key `showSelectedColorInHeadline` to optionally display the currently selected color swatch value (e.g. “Color: Red”) in the headline.
+
 ## 1.6.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Configuration for the link swatch
 - `showAdditionalText` (boolean) Shows an additional text underneath the link-swatch.
 - `historyReplace` (boolean) Replaces the route history.
 
+### showSelectedColorInHeadline (boolean)
+Displays the currently selected swatch value next to the headline label (e.g. `Color: Red`).  
+If set to `false`, only the label (e.g. `Color`) is shown.
+
 #### Example of full config:
 ```json
 {
@@ -153,7 +157,8 @@ Configuration for the link swatch
     "property": "linkSwatch",
     "showAdditionalText": true,
     "historyReplace": false
-  }
+  },
+  "showSelectedColorInHeadline": true
 }
 ```
 

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.6.0",
+  "version": "1.7.0-beta.1",
   "id": "@shopgate-project/fashion-swatches",
   "configuration": {
     "swatchColorStyle": {
@@ -183,6 +183,16 @@
       "params": {
         "label": "Configuration for the link swatch",
         "type": "json",
+        "required": true
+      }
+    },
+    "showSelectedColorInHeadline": {
+      "type": "admin",
+      "destination": "frontend",
+      "default": false,
+      "params": {
+        "label": "Show selected color in headline",
+        "type": "boolean",
         "required": true
       }
     }

--- a/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
+++ b/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
@@ -211,7 +211,7 @@ const FoldableSwatchesUnfolded = ({
         <div className={styles.swatchesContainer}>
           {label && pdpSwatchesDisplayMode === 'headline' && pdpSwatchesPosition === 'variants' && (
             <p className={classnames(styles.swatchHeadline, 'swatches__headline')} aria-hidden>
-              {`${label}${showSelectedColorInHeadline && selectedColor ? `: ${selectedColor.label}` : ''}`}
+              {`${label}${showSelectedColorInHeadline && selectedColor?.label ? `: ${selectedColor.label}` : ''}`}
             </p>
           )}
           <ul

--- a/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
+++ b/frontend/components/FoldableSwatches/components/Unfolded/index.jsx
@@ -14,6 +14,7 @@ import {
   swatchLinkStyle,
   pdpSwatchesDisplayMode,
   pdpSwatchesPosition,
+  showSelectedColorInHeadline,
 } from '../../../../config';
 
 const { pdp: colorStyleDefault = {}, pdpTablet: colorStyleTablet } = swatchColorStyle;
@@ -195,6 +196,11 @@ const FoldableSwatchesUnfolded = ({
     }
   }, [values, label, isTablet, highlighted]);
 
+  // Find selected color for headline
+  const selectedColor = values.find(
+    v => v.selected && (v.swatchColor || v.swatchImage)
+  );
+
   return (
     <Transition
       in={highlighted}
@@ -204,7 +210,9 @@ const FoldableSwatchesUnfolded = ({
       {state => (
         <div className={styles.swatchesContainer}>
           {label && pdpSwatchesDisplayMode === 'headline' && pdpSwatchesPosition === 'variants' && (
-            <p className={classnames(styles.swatchHeadline, 'swatches__headline')} aria-hidden>{label}</p>
+            <p className={classnames(styles.swatchHeadline, 'swatches__headline')} aria-hidden>
+              {`${label}${showSelectedColorInHeadline && selectedColor ? `: ${selectedColor.label}` : ''}`}
+            </p>
           )}
           <ul
             className={classnames(

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopgate-project/fashion-swatches",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Fashion swatch extension",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
# Pull Request Template

## Description

Add the config key `showSelectedColorInHeadline` to optionally display the currently selected color swatch value in the headline.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update